### PR TITLE
feat: add <favorite team>.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes, useLocation} from "react-router-dom";
 import { useDispatch, useSelector } from 'react-redux';
 import Header from "./header";
 import TopPage from "./topPage";
@@ -17,6 +17,7 @@ function App() {
   const dispatch = useDispatch();
   const userProf = useSelector(selectProfile);
   const isUserSignIn = useSelector(selectIsUserSignIn);
+  const location = useLocation();
 
   useEffect(() => {
     const fetchBootLoader = async () => {
@@ -28,18 +29,24 @@ function App() {
   }, [dispatch]);
 
   return (
-    <Router>
-      <Box sx={{ display: 'flex' }}>
-        <Sidebar />
-        <Box sx={{ flexGrow: 1, p: 3 }}>
-          <Routes>
-            <Route path="/" element={<TopPage />} />
-            <Route path="/board/:team" element={<BoardPage />} />
-          </Routes>
-        </Box>
+    <Box sx={{ display: 'flex' }}>
+      <Sidebar currentPath={location.pathname} />
+      <Box sx={{ flexGrow: 1, p: 3 }}>
+        <Routes>
+          <Route path="/" element={<TopPage />} />
+          <Route path="/board/:team" element={<BoardPage />} />
+        </Routes>
       </Box>
+    </Box>
+  );
+}
+
+function WrappedApp() {
+  return (
+    <Router>
+      <App />
     </Router>
   );
 }
 
-export default App;
+export default WrappedApp;

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import { Dashboard as DashboardIcon, Forum as ForumIcon } from "@mui/icons-material";
 import { styled } from "@mui/material/styles";
+import StarRateIcon from '@mui/icons-material/StarRate';
 
 const Logo = styled(Typography)(({ theme }) => ({
   padding: theme.spacing(2),
@@ -29,24 +30,26 @@ const StyledListItem = styled(ListItem)(({ theme }) => ({
 
 const teams = [
   { league: 'セ・リーグ', teams: [
-    { name: "巨人", path: "/board/giants" },
     { name: "阪神", path: "/board/tigers" },
-    { name: "中日", path: "/board/dragons" },
-    { name: "ヤクルト", path: "/board/swallows" },
-    { name: "DeNA", path: "/board/baystars" },
     { name: "広島", path: "/board/carp" },
+    { name: "DeNA", path: "/board/baystars" },
+    { name: "巨人", path: "/board/giants" },
+    { name: "ヤクルト", path: "/board/swallows" },
+    { name: "中日", path: "/board/dragons" },
   ]},
   { league: 'パ・リーグ', teams: [
-    { name: "ソフトバンク", path: "/board/hawks" },
-    { name: "西武", path: "/board/lions" },
-    { name: "楽天", path: "/board/eagles" },
-    { name: "ロッテ", path: "/board/marines" },
-    { name: "日本ハム", path: "/board/fighters" },
     { name: "オリックス", path: "/board/buffaloes" },
+    { name: "ロッテ", path: "/board/marines" },
+    { name: "ソフトバンク", path: "/board/hawks" },
+    { name: "楽天", path: "/board/eagles" },
+    { name: "西武", path: "/board/lions" },
+    { name: "日本ハム", path: "/board/fighters" },
   ]},
 ];
 
-function Sidebar() {
+const favoriteTeam = { name: "阪神タイガース", path: "/board/tigers" }
+
+function Sidebar({ currentPath }) {
   return (
     <Drawer
       variant="permanent"
@@ -64,8 +67,20 @@ function Sidebar() {
       </Box>
       <Divider />
       <List>
+      { currentPath === "/" ? (
         <StyledListItem 
-          button 
+          button
+          component={Link} 
+          to={favoriteTeam.path}
+        >
+          <ListItemIcon>
+            <StarRateIcon />
+          </ListItemIcon>
+          <ListItemText primary={ favoriteTeam.name } />
+        </StyledListItem>
+      ) : (
+        <StyledListItem
+          button
           component={Link} 
           to="/"
         >
@@ -74,6 +89,7 @@ function Sidebar() {
           </ListItemIcon>
           <ListItemText primary="ダッシュボード" />
         </StyledListItem>
+      )}
       </List>
       <Divider />
       {teams.map((league) => (

--- a/src/topPage.js
+++ b/src/topPage.js
@@ -12,20 +12,20 @@ import {
 
 const teams = [
   { league: 'セ・リーグ', teams: [
-    { name: "読売ジャイアンツ", path: "/board/giants", image: "/path_to_image/giants.jpg" },
     { name: "阪神タイガース", path: "/board/tigers", image: "/path_to_image/tigers.jpg" },
-    { name: "中日ドラゴンズ", path: "/board/dragons", image: "/path_to_image/dragons.jpg" },
-    { name: "東京ヤクルトスワローズ", path: "/board/swallows", image: "/path_to_image/swallows.jpg" },
-    { name: "横浜DeNAベイスターズ", path: "/board/baystars", image: "/path_to_image/baystars.jpg" },
     { name: "広島東洋カープ", path: "/board/carp", image: "/path_to_image/carp.jpg" },
+    { name: "横浜DeNAベイスターズ", path: "/board/baystars", image: "/path_to_image/baystars.jpg" },
+    { name: "読売ジャイアンツ", path: "/board/giants", image: "/path_to_image/giants.jpg" },
+    { name: "東京ヤクルトスワローズ", path: "/board/swallows", image: "/path_to_image/swallows.jpg" },
+    { name: "中日ドラゴンズ", path: "/board/dragons", image: "/path_to_image/dragons.jpg" },
   ]},
   { league: 'パ・リーグ', teams: [
-    { name: "福岡ソフトバンクホークス", path: "/board/hawks", image: "/path_to_image/hawks.jpg" },
-    { name: "埼玉西武ライオンズ", path: "/board/lions", image: "/path_to_image/lions.jpg" },
-    { name: "東北楽天ゴールデンイーグルス", path: "/board/eagles", image: "/path_to_image/eagles.jpg" },
-    { name: "千葉ロッテマリーンズ", path: "/board/marines", image: "/path_to_image/marines.jpg" },
-    { name: "北海道日本ハムファイターズ", path: "/board/fighters", image: "/path_to_image/fighters.jpg" },
     { name: "オリックス・バファローズ", path: "/board/buffaloes", image: "/path_to_image/buffaloes.jpg" },
+    { name: "千葉ロッテマリーンズ", path: "/board/marines", image: "/path_to_image/marines.jpg" },
+    { name: "福岡ソフトバンクホークス", path: "/board/hawks", image: "/path_to_image/hawks.jpg" },
+    { name: "東北楽天ゴールデンイーグルス", path: "/board/eagles", image: "/path_to_image/eagles.jpg" },
+    { name: "埼玉西武ライオンズ", path: "/board/lions", image: "/path_to_image/lions.jpg" },
+    { name: "北海道日本ハムファイターズ", path: "/board/fighters", image: "/path_to_image/fighters.jpg" },
   ]},
 ];
 
@@ -64,7 +64,7 @@ function TopPage() {
           </Typography>
           <Grid container spacing={3}>
             {league.teams.map((team) => (
-              <Grid item xs={12} sm={6} md={4} lg={3} key={team.path}>
+              <Grid item xs={12} sm={6} md={4} lg={4} key={team.path}>
                 <TeamCard team={team} />
               </Grid>
             ))}


### PR DESCRIPTION
### お気に入り機能の追加
Topページではお気に入りチーム、TLではダッシュボードが表示される。

<img width="320" src="https://github.com/user-attachments/assets/a4fe7dcf-63fc-4840-8827-11f91cb29bfe">
<img width="320" src="https://github.com/user-attachments/assets/1ba55f79-d0d5-462c-8f04-a00eb3552fb5">

### その他諸々細かい点の修正
ダッシュボードにおけるチーム別カードの配置について（3x2）、（2x3）、（1x12）になるようにする、等々。